### PR TITLE
Better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ endm
 ```
 
 Next, run Maude and input `in <filename.maude>`. Next, check that your plan runs without errors:
+
 ```
 Maude> rew init .
 ```
@@ -81,9 +82,49 @@ plan: end
 Here, we can see the final state of the feature model, with all the plans implemented. If it gets stuck, it will give an error message showing why, which can be used to correct the plan. If the plan is correct, like it is here, you can test temporal constraints:
 
 ```
-Maude> red modelCheck(init, feature "ChildID" exists after 1) .
-reduce in MY-PLAN : modelCheck(init, feature "ChildID" exists after 1) .
+Maude> red check(init, feature "ChildID" exists after 1) .
+reduce in MY-PLAN : check(init, feature "ChildID" exists
+    after 1) .
+SUCCESS
 result Bool: true
 ```
 
-If the constraint fails, it will give a counterexample, showing the path where the formula failed.
+### Output of program
+
+#### Soundness checker
+
+Since maude produces a lot of information that are hard to parse and make sense of, we have included print statements across the code that will give you all the necessary information. Running the maude modules should be run with the following command:
+
+```
+maude -print-to-stderr 1> /dev/null <filename.maude>
+```
+
+The `-print-to-stderr` flag will send all the print statements to the stderr channel, which allows us to disregard the standard output (stdout). If the program ran without errors, no output will be produced. However, if the plan contains errors, the output will report what went wrong, at what timepoint, and what operation. The output can look something like this:
+
+```
+ERROR: Feature with ID pilot does not exist.
+PLAN ERROR: 5 - addGroup(pilot, "pilot1", AND)
+```
+
+#### Model checker
+
+Assuming a sound plan, you construct and check temporal statements using the model checker. See `example.maude` for a full example. Given an initial model `init`, we can check the temporal properties like this:
+
+```
+red check(init, feature car exists at 2) .
+red check(init, neg feature distance exists at 2) .
+red check(init, group "comfort1" exists at 4) .
+red check(init, feature distance exists at 7) .
+```
+
+Each `check` statement will produce either `SUCCESS` or `FAILURE` print statements.
+
+Running such a module with `maude -print-to-stderr 1> /dev/null example.maude` will produce the following output:
+
+```
+SUCCESS
+SUCCESS
+SUCCESS
+FAILURE 
+```
+

--- a/example.maude
+++ b/example.maude
@@ -59,66 +59,68 @@ endm
 
 *** evolution plan ***
 red "*** at ***" .
-red modelCheck(init, feature car exists at 2) .
-red modelCheck(init, neg feature distance exists at 2) .
-red modelCheck(init, group "comfort1" exists at 4) .
-red modelCheck(init, ~ (feature distance exists at 7)) .
-red modelCheck(init, feature assistance exists starts at 2)  .
-red modelCheck(init, group "pilot1" exists starts andalso feature distance exists starts at 5) .
-red modelCheck(init, ~ (feature assistance exists starts at 4)) .
-red modelCheck(init, ~ (group "pilot1" exists starts at 4)) .
+red check(init, feature car exists at 2) .
+red check(init, neg feature distance exists at 2) .
+red check(init, group "comfort1" exists at 4) .
+red check(init, (feature distance exists at 7)) .
+red check(init, feature assistance exists starts at 2)  .
+red check(init, group "pilot1" exists starts andalso feature distance exists starts at 5) .
+red check(init, ~ (feature assistance exists starts at 4)) .
+red check(init, ~ (group "pilot1" exists starts at 4)) .
 red "*** when ***" .
-red modelCheck(init, group "comfort1" has type AND when group "Group1" has type OR starts) .
-red modelCheck(init, ~ (group "Group1" has type OR when group "comfort1" exists starts)) .
-red modelCheck(init, group "Group1" has type OR starts when group "pilot1" exists starts) .
-red modelCheck(init, feature sensors exists starts when feature distance has parent group "sensors1" starts) .
-red modelCheck(init, ~ (feature distance exists starts when feature pilot exists starts )) .
+red check(init, group "comfort1" has type AND when group "Group1" has type OR starts) .
+red check(init, ~ (group "Group1" has type OR when group "comfort1" exists starts)) .
+red check(init, group "Group1" has type OR starts when group "pilot1" exists starts) .
+red check(init, feature sensors exists starts when feature distance has parent group "sensors1" starts) .
+red check(init, ~ (feature distance exists starts when feature pilot exists starts )) .
 red "*** until ***" .
-red modelCheck(init, feature bluetooth exists until 7) .
-red modelCheck(init, ~ (feature pilot exists until 100)) .
-red modelCheck(init, feature bluetooth exists until feature frontSensors exists starts) .
-red modelCheck(init, ~ (feature pilot exists until feature distance exists stops)) .
+red check(init, feature bluetooth exists until 7) .
+red check(init, ~ (feature pilot exists until 100)) .
+red check(init, feature bluetooth exists until feature frontSensors exists starts) .
+red check(init, ~ (feature pilot exists until feature distance exists stops)) .
 red "*** before ***" .
-red modelCheck(init, group "comfort1" exists starts before 4) .
-red modelCheck(init, ~ (group "comfort1" exists starts before 2)) .
-red modelCheck(init, feature auto exists starts before feature brake exists starts) .
-red modelCheck(init, feature pilot exists starts before feature distance exists starts) .
-red modelCheck(init, feature assistance exists starts before group "Group1" has type OR starts) .
-red modelCheck(init, ~ (feature distance exists starts before feature pilot exists starts)) .
+red check(init, group "comfort1" exists starts before 4) .
+red check(init, ~ (group "comfort1" exists starts before 2)) .
+red check(init, feature auto exists starts before feature brake exists starts) .
+red check(init, feature pilot exists starts before feature distance exists starts) .
+red check(init, feature assistance exists starts before group "Group1" has type OR starts) .
+red check(init, ~ (feature distance exists starts before feature pilot exists starts)) .
 red "*** after ***" .
-red modelCheck(init, feature distance exists stops after feature distance exists starts) .
-red modelCheck(init, feature distance exists starts after feature pilot exists starts) .
-red modelCheck(init, ~ (feature pilot exists starts after feature distance exists starts)) .
-red modelCheck(init, feature pilot exists after 6) .
-red modelCheck(init, feature assistance exists after 2) .
-red modelCheck(init, ~ (feature distance exists after 5)) .
-red modelCheck(init, feature pilot exists after feature assistance exists starts) .
-red modelCheck(init, ~ (feature distance exists after group "pilot1" exists starts)) .
---- red modelCheck(init, (group "pilot1" exists andalso feature distance exists) starts at 5) . not supported!!!
+red check(init, feature distance exists stops after feature distance exists starts) .
+red check(init, feature distance exists starts after feature pilot exists starts) .
+red check(init, ~ (feature pilot exists starts after feature distance exists starts)) .
+red check(init, feature pilot exists after 6) .
+red check(init, feature assistance exists after 2) .
+red check(init, ~ (feature distance exists after 5)) .
+red check(init, feature pilot exists after feature assistance exists starts) .
+red check(init, ~ (feature distance exists after group "pilot1" exists starts)) .
+--- red check(init, (group "pilot1" exists andalso feature distance exists) starts at 5) . not supported!!!
 red "*** between ***" .
-red modelCheck(init, feature distance exists starts between 4 and 7) .
-red modelCheck(init, ~ (feature distance exists starts between 2 and 5)) .
-red modelCheck(init, feature distance exists starts between 4 and feature distance exists stops) .
-red modelCheck(init, ~ (feature distance exists starts between 2 and feature distance exists starts)) .
-red modelCheck(init, feature distance exists starts between feature pilot exists starts and 7) .
-red modelCheck(init, ~ (feature distance exists starts between feature pilot exists starts and 5)) .
-red modelCheck(init, feature distance exists starts between feature distance exists starts and feature distance exists stops) .
-red modelCheck(init, ~ (feature distance exists starts between feature pilot exists starts and feature distance exists starts)) .
+red check(init, feature distance exists starts between 4 and 7) .
+red check(init, ~ (feature distance exists starts between 2 and 5)) .
+red check(init, feature distance exists starts between 4 and feature distance exists stops) .
+red check(init, ~ (feature distance exists starts between 2 and feature distance exists starts)) .
+red check(init, feature distance exists starts between feature pilot exists starts and 7) .
+red check(init, ~ (feature distance exists starts between feature pilot exists starts and 5)) .
+red check(init, feature distance exists starts between feature distance exists starts and feature distance exists stops) .
+red check(init, ~ (feature distance exists starts between feature pilot exists starts and feature distance exists starts)) .
 red "*** always ***" .
-red modelCheck(init, always feature car exists) .
-red modelCheck(init, ~ (always feature auto exists)) .
+red check(init, always feature car exists) .
+red check(init, ~ (always feature auto exists)) .
 red "*** while ***" .
-red modelCheck(init, feature auto exists while feature brake exists) .
-red modelCheck(init, ~ (feature brake exists while feature auto exists)) .
-red modelCheck(init, feature distance exists stops while group "pilot1" exists) .
-red modelCheck(init, ~ (feature distance exists stops while (neg (group "pilot1" exists)))) .
+red check(init, feature auto exists while feature brake exists) .
+red check(init, ~ (feature brake exists while feature auto exists)) .
+red check(init, feature distance exists stops while group "pilot1" exists) .
+red check(init, ~ (feature distance exists stops while (neg (group "pilot1" exists)))) .
 red "*** while between ***" .
-red modelCheck(init, feature distance exists while between 5 and 7) .
-red modelCheck(init, ~ (feature distance exists while between 2 and 7)) .
-red modelCheck(init, feature distance exists while between 5 and feature frontSensors exists starts) .
-red modelCheck(init, ~ (group "Group1" has type ALTERNATIVE while between 2 and feature brake exists starts)) .
-red modelCheck(init, feature distance exists while between group "pilot1" exists starts and 7) .
-red modelCheck(init, ~ (feature distance exists while between group "Group1" exists starts and 7)) .
-red modelCheck(init, feature distance exists while between group "pilot1" exists starts and feature frontSensors exists starts) .
-red modelCheck(init, feature distance exists while between feature distance exists starts and feature distance exists stops) .
-red modelCheck(init, ~ (group "Group1" has type ALTERNATIVE while between feature pilot exists starts and feature sensors exists starts)) .
+red check(init, feature distance exists while between 5 and 7) .
+red check(init, ~ (feature distance exists while between 2 and 7)) .
+red check(init, feature distance exists while between 5 and feature frontSensors exists starts) .
+red check(init, ~ (group "Group1" has type ALTERNATIVE while between 2 and feature brake exists starts)) .
+red check(init, feature distance exists while between group "pilot1" exists starts and 7) .
+red check(init, (feature distance exists while between group "Group1" exists starts and 7)) .
+red check(init, feature distance exists while between group "pilot1" exists starts and feature frontSensors exists starts) .
+red check(init, feature distance exists while between feature distance exists starts and feature distance exists stops) .
+red check(init, (group "Group1" has type ALTERNATIVE while between feature pilot exists starts and feature sensors exists starts)) .
+
+q

--- a/example.maude
+++ b/example.maude
@@ -62,61 +62,61 @@ red "*** at ***" .
 red check(init, feature car exists at 2) .
 red check(init, neg feature distance exists at 2) .
 red check(init, group "comfort1" exists at 4) .
-red check(init, (feature distance exists at 7)) .
+red check(init, feature distance exists at 7) .
 red check(init, feature assistance exists starts at 2)  .
 red check(init, group "pilot1" exists starts andalso feature distance exists starts at 5) .
-red check(init, ~ (feature assistance exists starts at 4)) .
-red check(init, ~ (group "pilot1" exists starts at 4)) .
+red check(init, feature assistance exists starts at 4) .
+red check(init, group "pilot1" exists starts at 4) .
 red "*** when ***" .
 red check(init, group "comfort1" has type AND when group "Group1" has type OR starts) .
-red check(init, ~ (group "Group1" has type OR when group "comfort1" exists starts)) .
+red check(init, group "Group1" has type OR when group "comfort1" exists starts) .
 red check(init, group "Group1" has type OR starts when group "pilot1" exists starts) .
 red check(init, feature sensors exists starts when feature distance has parent group "sensors1" starts) .
-red check(init, ~ (feature distance exists starts when feature pilot exists starts )) .
+red check(init, feature distance exists starts when feature pilot exists starts ) .
 red "*** until ***" .
 red check(init, feature bluetooth exists until 7) .
-red check(init, ~ (feature pilot exists until 100)) .
+red check(init, feature pilot exists until 100) .
 red check(init, feature bluetooth exists until feature frontSensors exists starts) .
-red check(init, ~ (feature pilot exists until feature distance exists stops)) .
+red check(init, feature pilot exists until feature distance exists stops) .
 red "*** before ***" .
 red check(init, group "comfort1" exists starts before 4) .
-red check(init, ~ (group "comfort1" exists starts before 2)) .
+red check(init, group "comfort1" exists starts before 2) .
 red check(init, feature auto exists starts before feature brake exists starts) .
 red check(init, feature pilot exists starts before feature distance exists starts) .
 red check(init, feature assistance exists starts before group "Group1" has type OR starts) .
-red check(init, ~ (feature distance exists starts before feature pilot exists starts)) .
+red check(init, feature distance exists starts before feature pilot exists starts) .
 red "*** after ***" .
 red check(init, feature distance exists stops after feature distance exists starts) .
 red check(init, feature distance exists starts after feature pilot exists starts) .
-red check(init, ~ (feature pilot exists starts after feature distance exists starts)) .
+red check(init, feature pilot exists starts after feature distance exists starts) .
 red check(init, feature pilot exists after 6) .
 red check(init, feature assistance exists after 2) .
-red check(init, ~ (feature distance exists after 5)) .
+red check(init, feature distance exists after 5) .
 red check(init, feature pilot exists after feature assistance exists starts) .
-red check(init, ~ (feature distance exists after group "pilot1" exists starts)) .
+red check(init, feature distance exists after group "pilot1" exists starts) .
 --- red check(init, (group "pilot1" exists andalso feature distance exists) starts at 5) . not supported!!!
 red "*** between ***" .
 red check(init, feature distance exists starts between 4 and 7) .
-red check(init, ~ (feature distance exists starts between 2 and 5)) .
+red check(init, feature distance exists starts between 2 and 5) .
 red check(init, feature distance exists starts between 4 and feature distance exists stops) .
-red check(init, ~ (feature distance exists starts between 2 and feature distance exists starts)) .
+red check(init, feature distance exists starts between 2 and feature distance exists starts) .
 red check(init, feature distance exists starts between feature pilot exists starts and 7) .
-red check(init, ~ (feature distance exists starts between feature pilot exists starts and 5)) .
+red check(init, feature distance exists starts between feature pilot exists starts and 5) .
 red check(init, feature distance exists starts between feature distance exists starts and feature distance exists stops) .
-red check(init, ~ (feature distance exists starts between feature pilot exists starts and feature distance exists starts)) .
+red check(init, feature distance exists starts between feature pilot exists starts and feature distance exists starts) .
 red "*** always ***" .
 red check(init, always feature car exists) .
-red check(init, ~ (always feature auto exists)) .
+red check(init, always feature auto exists) .
 red "*** while ***" .
 red check(init, feature auto exists while feature brake exists) .
-red check(init, ~ (feature brake exists while feature auto exists)) .
+red check(init, feature brake exists while feature auto exists) .
 red check(init, feature distance exists stops while group "pilot1" exists) .
-red check(init, ~ (feature distance exists stops while (neg (group "pilot1" exists)))) .
+red check(init, feature distance exists stops while (neg (group "pilot1" exists))) .
 red "*** while between ***" .
 red check(init, feature distance exists while between 5 and 7) .
-red check(init, ~ (feature distance exists while between 2 and 7)) .
+red check(init, feature distance exists while between 2 and 7) .
 red check(init, feature distance exists while between 5 and feature frontSensors exists starts) .
-red check(init, ~ (group "Group1" has type ALTERNATIVE while between 2 and feature brake exists starts)) .
+red check(init, group "Group1" has type ALTERNATIVE while between 2 and feature brake exists starts) .
 red check(init, feature distance exists while between group "pilot1" exists starts and 7) .
 red check(init, (feature distance exists while between group "Group1" exists starts and 7)) .
 red check(init, feature distance exists while between group "pilot1" exists starts and feature frontSensors exists starts) .

--- a/featuremodel-checker.maude
+++ b/featuremodel-checker.maude
@@ -170,4 +170,9 @@ mod FEATUREMODEL-CHECKER is including MODEL-CHECKER + FEATURE-MODEL-TIME . prote
   eq Ent while between Ev and TP  = <> (Ev                 /\ (Ent U incl after TP))  .
   eq Ent while between Ev and Ev' = <> (Ev                 /\ (Ent U Ev'))            .
 
+  --- Sensible error messages from modelCheck
+  var S : State . var Form : Formula .
+  op check : State Prop -> Bool .
+  ceq check(S, Form) = true if modelCheck(S, Form) .
+  eq check(S, Form) = false [owise print "MODEL CHECK ERROR: " Form] .
 endm

--- a/featuremodel-checker.maude
+++ b/featuremodel-checker.maude
@@ -173,6 +173,6 @@ mod FEATUREMODEL-CHECKER is including MODEL-CHECKER + FEATURE-MODEL-TIME . prote
   --- Sensible error messages from modelCheck
   var S : State . var Form : Formula .
   op check : State Prop -> Bool .
-  ceq check(S, Form) = true if modelCheck(S, Form) .
-  eq check(S, Form) = false [owise print "MODEL CHECK ERROR: " Form] .
+  ceq check(S, Form) = true if modelCheck(S, Form) [print "SUCCESS"] .
+  eq check(S, Form) = false [owise print "FAILURE"] .
 endm

--- a/featuremodel.maude
+++ b/featuremodel.maude
@@ -24,7 +24,7 @@ fmod FEATURE-MODEL is protecting STRING .
   op  g          : GroupID GroupType Features -> Group     [ctor format (r o)] .
   op  noG        :                            -> Groups    [ctor format (r o)] .
   op  _::_       : Groups  Groups             -> Groups    [ctor assoc comm id: noG] .
-  ops AND OR ALTERNATIVE :                            -> GroupType [ctor] .
+  ops AND OR ALTERNATIVE :                    -> GroupType [ctor] .
 
   --- Define configurations as Feature model + list of operations
   sorts Configuration Operations Operation Event Log Entity .
@@ -32,6 +32,7 @@ fmod FEATURE-MODEL is protecting STRING .
   subsort Event     < Log .
 
   op _#_#_ : FeatureModel Operations Log -> Configuration [ctor format (ni ni ni ni ni d)] .
+  op errorConfiguration : Operation      -> Configuration [ctor] .
   op done  :                             -> Operations    [ctor format (g o)] .
   op __    : Operations   Operations     -> Operations    [ctor assoc id: done format (d ni d)] .
 
@@ -257,6 +258,14 @@ fmod FEATURE-MODEL is protecting STRING .
   /\ isWellFormed(FT'''', Fid)
   /\ Gid := parentGroup(FT, Fid) /\ Gid =/= parentGroupError .
 
+  eq [move-feature] :
+      FM(RootFid, FT)
+      # moveFeature(Fid, NewGroup) Ops
+      # L
+    =
+      errorConfiguration(moveFeature(Fid, NewGroup))
+    [owise] .
+
   ceq [rename-feature] :
       FM(RootFid, FT)
       # renameFeature(Fid, NewName) Ops
@@ -270,6 +279,14 @@ fmod FEATURE-MODEL is protecting STRING .
       L
   if [Fid -> f(Name, ParentFid, Gs, FType)] ++ FT' := split: FT onFid: Fid ;
   /\ isUniqueName(NewName, FT) .
+
+  eq [rename-feature] :
+      FM(RootFid, FT)
+      # renameFeature(Fid, NewName) Ops
+      # L
+    =
+      errorConfiguration(renameFeature(Fid, NewName))
+    [owise] .
 
   ceq [change-feature-variation-type] :
       FM(RootFid, FT)
@@ -287,6 +304,14 @@ fmod FEATURE-MODEL is protecting STRING .
   /\ FT'' := FT' + [Fid -> f(Name, ParentFid, Gs, FType')]
   /\ isWellFormed(FT'', Fid) .
 
+  eq [change-feature-variation-type] :
+      FM(RootFid, FT)
+      # changeFeatureType(Fid, FType') Ops
+      # L
+    =
+      errorConfiguration(changeFeatureType(Fid, FType'))
+    [owise] .
+
   ceq [add-group] :
       FM(RootFid, FT)
       # addGroup(Fid, Gid, GType) Ops
@@ -303,6 +328,14 @@ fmod FEATURE-MODEL is protecting STRING .
   if [Fid -> f(Name, ParentFid, Gs, FType)] ++ FT' := split: FT onFid: Fid ;
   /\ isUniqueGroupID(Gid, FT + [Fid -> f(Name, ParentFid, Gs, FType)]) .
 
+  eq [add-group] :
+      FM(RootFid, FT)
+      # addGroup(Fid, Gid, GType) Ops
+      # L
+    =
+      errorConfiguration(addGroup(Fid, Gid, GType))
+    [owise] .
+
   ceq [remove-group] :
       FM(RootFid, FT)
       # removeGroup(Gid) Ops
@@ -318,6 +351,14 @@ fmod FEATURE-MODEL is protecting STRING .
   if [Fid -> f(Name, ParentFid, g(Gid, GType, Fs) :: Gs, FType)] ++ FT' := split: FT onGroupID: Gid ;
   /\ isEmptyFeatures(Fs) .
 
+  eq [remove-group] :
+      FM(RootFid, FT)
+      # removeGroup(Gid) Ops
+      # L
+    =
+      errorConfiguration(removeGroup(Gid))
+    [owise] .
+
   ceq [change-group-variation-type] :
       FM(RootFid, FT)
       # changeGroupType(Gid, GType) Ops
@@ -332,6 +373,14 @@ fmod FEATURE-MODEL is protecting STRING .
   if [ParentFid -> f(Name, ParentOfTarget, g(Gid, GType', Fs) :: Gs, FType)] ++ FT' := split: FT onGroupID: Gid ;
   /\ FT'' := FT' + [ParentFid -> f(Name, ParentOfTarget, g(Gid, GType, Fs) :: Gs, FType)]
   /\ allWellFormed(Fs, FT'') .
+
+  eq [change-group-variation-type] :
+      FM(RootFid, FT)
+      # changeGroupType(Gid, GType) Ops
+      # L
+    =
+      errorConfiguration(changeGroupType(Gid, GType))
+    [owise] .
 
   ceq [move-group] :
       FM(RootFid, FT)
@@ -353,6 +402,14 @@ fmod FEATURE-MODEL is protecting STRING .
   /\ FT'''' := updateParents(FT''', Fs, NewParent) /\ FT'''' =/= updateParentsError
   /\ allNotSubFeature(Fs, NewParent, RootFid, FT) .
 
+  eq [move-group] :
+      FM(RootFid, FT)
+      # moveGroup(Gid, NewParent) Ops
+      # L
+    =
+      errorConfiguration(moveGroup(Gid, NewParent))
+    [owise] .
+
 endfm
 
 mod FEATURE-MODEL-TIME is protecting FEATURE-MODEL .
@@ -362,6 +419,7 @@ mod FEATURE-MODEL-TIME is protecting FEATURE-MODEL .
 
   op endTime                :                               -> TimePoint         [ctor] .
   op currentTime:_C:_plan:_ : TimePoint Configuration Plans -> TimeConfiguration [ctor format(bn o bn o bn o d)] .
+  op planError : TimePoint Operation           -> TimeConfiguration [ctor]
   op at_do_;                : TimePoint Operations          -> Plan              [ctor format (mn o m on d d)] .
   op end                    :                               -> Plans             [ctor] .
   op _;;_                   : Plans Plans                   -> Plans             [ctor assoc id: end] .
@@ -369,6 +427,7 @@ mod FEATURE-MODEL-TIME is protecting FEATURE-MODEL .
   var  RootFid : FeatureID    .
   var  FT      : FeatureTable .
   var  L       : Log          .
+  var  Op      : Operation    .
   var  Ops     : Operations   .
   vars CT TP   : Nat          .
   var  Ps      : Plans        .
@@ -383,6 +442,13 @@ mod FEATURE-MODEL-TIME is protecting FEATURE-MODEL .
       currentTime: CT      C: FM(RootFid, FT) # done # L     plan: end
     =>
       currentTime: endTime C: FM(RootFid, FT) # done # empty plan: end .
+
+  --- Stop if error has occured. Print error message
+  eq [paradox] :
+      currentTime: CT C: errorConfiguration(Op) plan: Ps
+    =
+      planError(CT, Op)
+    [print "PLAN ERROR: " CT " - " Op] .
 
 endm
 

--- a/featuremodel.maude
+++ b/featuremodel.maude
@@ -214,6 +214,14 @@ fmod FEATURE-MODEL is protecting STRING .
   /\ FT'' := FT' + [NewFid -> f(NewName, ParentFid, noG, FType)]
   /\ isWellFormed(FT'', NewFid) .
 
+  eq [add-feature] :
+      FM(RootFid, FT)
+      # addFeature(NewFid, NewName, TargetGroup, FType) Ops
+      # L
+    =
+      errorConfiguration(addFeature(NewFid, NewName, TargetGroup, FType))
+    [owise] .
+
   ceq [remove-feature] :
       FM(RootFid, FT)
       # removeFeature(Fid) Ops
@@ -234,6 +242,14 @@ fmod FEATURE-MODEL is protecting STRING .
   /\ Gid := parentGroup(FT, Fid) /\ Gid =/= parentGroupError
   /\ FT'' := removeFeatureFromParent(FT', ParentFid, Fid)
   /\ FT'' =/= removeFeatureFromParentError .
+
+  eq [remove-feature] :
+      FM(RootFid, FT)
+      # removeFeature(Fid) Ops
+      # L
+    =
+      errorConfiguration(removeFeature(Fid))
+    [owise] .
 
   ceq [move-feature] :
       FM(RootFid, FT)

--- a/featuremodel.maude
+++ b/featuremodel.maude
@@ -419,7 +419,7 @@ mod FEATURE-MODEL-TIME is protecting FEATURE-MODEL .
 
   op endTime                :                               -> TimePoint         [ctor] .
   op currentTime:_C:_plan:_ : TimePoint Configuration Plans -> TimeConfiguration [ctor format(bn o bn o bn o d)] .
-  op planError : TimePoint Operation           -> TimeConfiguration [ctor]
+  op planError              : TimePoint Operation           -> TimeConfiguration [ctor] .
   op at_do_;                : TimePoint Operations          -> Plan              [ctor format (mn o m on d d)] .
   op end                    :                               -> Plans             [ctor] .
   op _;;_                   : Plans Plans                   -> Plans             [ctor assoc id: end] .


### PR DESCRIPTION
Implemented a better system for logging the output of the system. The output of the program relies 100% of the print statements, so maude's normal output can be disregarded completely, allowing us to use the command `maude -print-to-stderr 1> /dev/null <filename.maude>` to produce just the necessary information. Consult the README section about [output of the program](https://github.com/idamotz/LTEP-summer-project/tree/better-logging#output-of-program) for documentation. 